### PR TITLE
Demo: Alpha & Port Reuse

### DIFF
--- a/gui/SlidersOfEvil/main.cpp
+++ b/gui/SlidersOfEvil/main.cpp
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
+
 int main(int argc, char* argv[]) {
  if (getuid()) {
    printf("%s", "You must run this program as root!\n");

--- a/gui/SlidersOfEvil/mainwindow.cpp
+++ b/gui/SlidersOfEvil/mainwindow.cpp
@@ -71,49 +71,45 @@ void MainWindow::on_chk_hystart_toggled(bool checked) {
   //   "(echo -n hystart: ) && (cat /sys/module/tcp_evil/parameters/hystart)");
 }
 
-void MainWindow::on_slider_beta_sliderMoved(int position) {
+void MainWindow::on_slider_alpha_valueChanged(int value) {
   stringstream ss;
-  ss << "echo -n " << position << " > /sys/module/tcp_evil/parameters/beta";
+  ss << "echo -n " << value <<
+    " > /sys/module/tcp_evil/parameters/alpha";
   system(ss.str().c_str());
 }
 
-void MainWindow::on_slider_beta_sliderReleased() {
-  // system(
-  //   "(echo -n beta: ) && (cat /sys/module/tcp_evil/parameters/beta)");
+void MainWindow::on_slider_beta_valueChanged(int value) {
+  stringstream ss;
+  ss << "echo -n " << value << " > /sys/module/tcp_evil/parameters/beta";
+  system(ss.str().c_str());
 }
 
-void MainWindow::on_slider_ack_delta_sliderMoved(int position) {
+void MainWindow::on_slider_ack_delta_valueChanged(int value) {
   stringstream ss;
-  ss << "echo -n " << position <<
+  ss << "echo -n " << value <<
     " > /sys/module/tcp_evil/parameters/hystart_ack_delta";
   system(ss.str().c_str());
 }
 
-void MainWindow::on_slider_ack_delta_sliderReleased() {
-  // system(
-  //   "(echo -n hystart_ack_delta: ) && (cat /sys/module/tcp_evil/parameters/hystart_ack_delta)");
-}
-
-void MainWindow::on_slider_low_window_sliderMoved(int position) {
+void MainWindow::on_slider_low_window_valueChanged(int value) {
   stringstream ss;
-  ss << "echo -n " << position <<
+  ss << "echo -n " << value <<
     " > /sys/module/tcp_evil/parameters/hystart_low_window";
   system(ss.str().c_str());
 }
 
-void MainWindow::on_slider_low_window_sliderReleased() {
-  // system(
-  //   "(echo -n hystart_low_window: ) && (cat /sys/module/tcp_evil/parameters/hystart_low_window)");
-}
-
-void MainWindow::on_slider_ssthresh_sliderMoved(int position) {
+void MainWindow::on_slider_ssthresh_valueChanged(int value) {
   stringstream ss;
-  ss << "echo -n " << position <<
+  ss << "echo -n " << value <<
     " > /sys/module/tcp_evil/parameters/initial_ssthresh";
   system(ss.str().c_str());
 }
 
-void MainWindow::on_slider_ssthresh_sliderReleased() {
-  // system(
-  //   "(echo -n initial_ssthresh: ) && (cat /sys/module/tcp_evil/parameters/initial_ssthresh)");
+void MainWindow::on_chk_use_alpha_toggled(bool checked) {
+  if (checked) {
+    system("echo -n 1 > /sys/module/tcp_evil/parameters/use_alpha");
+  }
+  else {
+    system("echo -n 0 > /sys/module/tcp_evil/parameters/use_alpha");
+  }
 }

--- a/gui/SlidersOfEvil/mainwindow.cpp
+++ b/gui/SlidersOfEvil/mainwindow.cpp
@@ -71,7 +71,6 @@ void MainWindow::on_actionExit_triggered() {
 }
 
 void MainWindow::updateGUI(const QString& str) {
-  cout << "[info] Update GUI" << endl;
   string value;
   int i_value;
   if (str.toStdString() == "/sys/module/tcp_evil/parameters/alpha") {

--- a/gui/SlidersOfEvil/mainwindow.cpp
+++ b/gui/SlidersOfEvil/mainwindow.cpp
@@ -1,32 +1,65 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
+#include <QDebug>
+#include <QMessageBox>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <stdio.h>
 #include <string>
-#include <memory>
 
 using namespace std;
 
 /** from http://stackoverflow.com/questions/478898/how-to-execute-a-command-and-get-output-of-command-within-c */
 std::string exec(const char* cmd) {
-    shared_ptr<FILE> pipe(popen(cmd, "r"), pclose);
-    if (!pipe) return "ERROR";
-    char buffer[128];
-    string result = "";
-    while (!feof(pipe.get())) {
-        if (fgets(buffer, 128, pipe.get()) != NULL)
-            result += buffer;
+  shared_ptr<FILE> pipe(popen(cmd, "r"), pclose);
+  if (!pipe) {
+    return "ERROR";
+  }
+  char buffer[128];
+  string result = "";
+  while (!feof(pipe.get())) {
+    if (fgets(buffer, 128, pipe.get()) != NULL) {
+      result += buffer;
     }
-    return result;
+  }
+  return result;
 }
 
 MainWindow::MainWindow(QWidget* parent) :
   QMainWindow(parent),
   ui(new Ui::MainWindow) {
   ui->setupUi(this);
+
+  //On startup read values and update GUI to match
+  updateGUI("/sys/module/tcp_evil/parameters/alpha");
+  updateGUI("/sys/module/tcp_evil/parameters/beta");
+  updateGUI("/sys/module/tcp_evil/parameters/fast_convergence");
+  updateGUI("/sys/module/tcp_evil/parameters/hystart");
+  updateGUI("/sys/module/tcp_evil/parameters/hystart_ack_delta");
+  updateGUI("/sys/module/tcp_evil/parameters/hystart_detect");
+  updateGUI("/sys/module/tcp_evil/parameters/hystart_low_window");
+  updateGUI("/sys/module/tcp_evil/parameters/initial_ssthresh");
+  updateGUI("/sys/module/tcp_evil/parameters/tcp_friendliness");
+
+  // Location of the TCP Evil Parameters
+  watcher.addPath("/sys/module/tcp_evil/parameters/alpha");
+  watcher.addPath("/sys/module/tcp_evil/parameters/beta");
+  watcher.addPath("/sys/module/tcp_evil/parameters/fast_convergence");
+  watcher.addPath("/sys/module/tcp_evil/parameters/hystart");
+  watcher.addPath("/sys/module/tcp_evil/parameters/hystart_ack_delta");
+  watcher.addPath("/sys/module/tcp_evil/parameters/hystart_detect");
+  watcher.addPath("/sys/module/tcp_evil/parameters/hystart_low_window");
+  watcher.addPath("/sys/module/tcp_evil/parameters/initial_ssthresh");
+  watcher.addPath("/sys/module/tcp_evil/parameters/tcp_friendliness");
+  QStringList fileList = watcher.files();
+  Q_FOREACH(QString file, fileList)
+  qDebug() << "[info] Watching: " << file << "\n";
+
+  QObject::connect(&watcher, SIGNAL(fileChanged(QString)), this,
+                   SLOT(updateGUI(QString)));
 }
 
 MainWindow::~MainWindow() {
@@ -37,13 +70,103 @@ void MainWindow::on_actionExit_triggered() {
   exit(EXIT_SUCCESS);
 }
 
+void MainWindow::updateGUI(const QString& str) {
+  cout << "[info] Update GUI" << endl;
+  string value;
+  int i_value;
+  if (str.toStdString() == "/sys/module/tcp_evil/parameters/alpha") {
+    value = exec("cat /sys/module/tcp_evil/parameters/alpha");
+    value.pop_back(); // remove the newline
+    i_value = stoi(value);
+    ui->alpha_value->setValue(i_value);
+  }
+  else if (str.toStdString() == "/sys/module/tcp_evil/parameters/beta") {
+    value = exec("cat /sys/module/tcp_evil/parameters/beta");
+    value.pop_back(); // remove the newline
+    i_value = stoi(value);
+    ui->beta_value->setValue(i_value);
+  }
+  else if (str.toStdString() ==
+           "/sys/module/tcp_evil/parameters/fast_convergence") {
+    value = exec("cat /sys/module/tcp_evil/parameters/fast_convergence");
+    value.pop_back(); // remove the newline
+    i_value = stoi(value);
+    if (i_value == 1) {
+      ui->chk_fast_convergence->setChecked(true);
+    }
+    else {
+      ui->chk_fast_convergence->setChecked(false);
+    }
+  }
+  else if (str.toStdString() == "/sys/module/tcp_evil/parameters/hystart") {
+    value = exec("cat /sys/module/tcp_evil/parameters/hystart");
+    value.pop_back(); // remove the newline
+    i_value = stoi(value);
+    if (i_value == 1) {
+      ui->chk_hystart->setChecked(true);
+    }
+    else {
+      ui->chk_hystart->setChecked(false);
+    }
+  }
+  else if (str.toStdString() ==
+           "/sys/module/tcp_evil/parameters/hystart_ack_delta") {
+    value = exec("cat /sys/module/tcp_evil/parameters/hystart_ack_delta");
+    value.pop_back(); // remove the newline
+    i_value = stoi(value);
+    ui->hystartackdelta_value->setValue(i_value);
+  }
+  else if (str.toStdString() ==
+           "/sys/module/tcp_evil/parameters/hystart_detect") {
+    value = exec("cat /sys/module/tcp_evil/parameters/hystart_detect");
+    value.pop_back(); // remove the newline
+    i_value = stoi(value);
+    switch (i_value) {
+    case 1:
+      ui->rb_packet_train->setChecked(true);
+      break;
+    case 2:
+      ui->rb_delay->setChecked(true);
+      break;
+    default:
+      ui->rb_both->setChecked(true);
+      break;
+    }
+  }
+  else if (str.toStdString() ==
+           "/sys/module/tcp_evil/parameters/hystart_low_window") {
+    value = exec("cat /sys/module/tcp_evil/parameters/hystart_low_window");
+    value.pop_back(); // remove the newline
+    i_value = stoi(value);
+    ui->low_window_value->setValue(i_value);
+  }
+  else if (str.toStdString() ==
+           "/sys/module/tcp_evil/parameters/initial_ssthresh") {
+    value = exec("cat /sys/module/tcp_evil/parameters/initial_ssthresh");
+    value.pop_back(); // remove the newline
+    i_value = stoi(value);
+    ui->ssthresh_value->setValue(i_value);
+  }
+  else if (str.toStdString() ==
+           "/sys/module/tcp_evil/parameters/tcp_friendliness") {
+    value = exec("cat /sys/module/tcp_evil/parameters/tcp_friendliness");
+    value.pop_back(); // remove the newline
+    i_value = stoi(value);
+    if (i_value == 1) {
+      ui->chk_tcp_friendliness->setChecked(true);
+    }
+    else {
+      ui->chk_tcp_friendliness->setChecked(false);
+    }
+  }
+}
+
 void MainWindow::on_rb_packet_train_clicked() {
   int status;
   status = system("echo -n 1 > /sys/module/tcp_evil/parameters/hystart_detect");
   if (status != 0) {
     cout << "[ERROR] Could not set hystart_detect." << endl;
   }
-  cout << "Hystart Detect set to Packet Train" << endl;
 }
 
 void MainWindow::on_rb_delay_clicked() {
@@ -52,7 +175,6 @@ void MainWindow::on_rb_delay_clicked() {
   if (status != 0) {
     cout << "[ERROR] Could not set hystart_detect." << endl;
   }
-  cout << "Hystart Detect set to Delay" << endl;
 }
 
 void MainWindow::on_rb_both_clicked() {
@@ -61,7 +183,6 @@ void MainWindow::on_rb_both_clicked() {
   if (status != 0) {
     cout << "[ERROR] Could not set hystart_detect." << endl;
   }
-  cout << "Hystart Detect set to both Delay and Packet Train" << endl;
 }
 
 void MainWindow::on_chk_fast_convergence_toggled(bool checked) {
@@ -176,7 +297,7 @@ void MainWindow::on_slider_rto_min_valueChanged(int value) {
   string s = "rto_min";
   string::size_type i = route.find(s);
   if (i != string::npos) {
-    route.erase(route.begin()+i, route.end());
+    route.erase(route.begin() + i, route.end());
   }
   else {
     route.pop_back();
@@ -206,40 +327,20 @@ void MainWindow::on_slider_rtt_valueChanged(int value) {
 void MainWindow::on_slider_rttvar_valueChanged(int value) {
 }
 
-void MainWindow::on_btn_restoreDefaults_clicked()
-{
-    // Set defaults
-    int e;
-    e = system("echo -n 3 > /sys/module/tcp_evil/parameters/hystart_detect");
-    if (e != 0) {
-      cout << "[ERROR] Couldn't set defaults." << endl;
-    }
-    e = system("echo -n 1 > /sys/module/tcp_evil/parameters/fast_convergence");
-    if (e != 0) {
-      cout << "[ERROR] Couldn't set defaults." << endl;
-    }
-    e = system("echo -n 1 > /sys/module/tcp_evil/parameters/tcp_friendliness");
-    if (e != 0) {
-      cout << "[ERROR] Couldn't set defaults." << endl;
-    }
-    e = system("echo -n 1 > /sys/module/tcp_evil/parameters/hystart");
-    if (e != 0) {
-      cout << "[ERROR] Couldn't set defaults." << endl;
-    }
-    e = system("echo -n 0 > /sys/module/tcp_evil/parameters/initial_ssthresh");
-    if (e != 0) {
-      cout << "[ERROR] Couldn't set defaults." << endl;
-    }
-    e = system("echo -n 16 > /sys/module/tcp_evil/parameters/hystart_low_window");
-    if (e != 0) {
-      cout << "[ERROR] Couldn't set defaults." << endl;
-    }
-    e = system("echo -n 2 > /sys/module/tcp_evil/parameters/hystart_ack_delta");
-    if (e != 0) {
-      cout << "[ERROR] Couldn't set defaults." << endl;
-    }
-    e = system("echo -n 717 > /sys/module/tcp_evil/parameters/beta");
-    if (e != 0) {
-      cout << "[ERROR] Couldn't set defaults." << endl;
-    }
+void MainWindow::on_btn_restoreDefaults_clicked() {
+  // Set defaults
+  int e;
+  e = system("echo -n 3 > /sys/module/tcp_evil/parameters/hystart_detect && "
+             "echo -n 1 > /sys/module/tcp_evil/parameters/fast_convergence && "
+             "echo -n 1 > /sys/module/tcp_evil/parameters/tcp_friendliness && "
+             "echo -n 1 > /sys/module/tcp_evil/parameters/hystart && "
+             "echo -n 1 > /sys/module/tcp_evil/parameters/hystart && "
+             "echo -n 0 > /sys/module/tcp_evil/parameters/initial_ssthresh && "
+             "echo -n 16 > /sys/module/tcp_evil/parameters/hystart_low_window && "
+             "echo -n 2 > /sys/module/tcp_evil/parameters/hystart_ack_delta && "
+             "echo -n 717 > /sys/module/tcp_evil/parameters/beta && "
+             "echo -n 1 > /sys/module/tcp_evil/parameters/alpha");
+  if (e != 0) {
+    cout << "[ERROR] Couldn't set defaults." << endl;
+  }
 }

--- a/gui/SlidersOfEvil/mainwindow.cpp
+++ b/gui/SlidersOfEvil/mainwindow.cpp
@@ -54,9 +54,6 @@ MainWindow::MainWindow(QWidget* parent) :
   watcher.addPath("/sys/module/tcp_evil/parameters/hystart_low_window");
   watcher.addPath("/sys/module/tcp_evil/parameters/initial_ssthresh");
   watcher.addPath("/sys/module/tcp_evil/parameters/tcp_friendliness");
-  QStringList fileList = watcher.files();
-  Q_FOREACH(QString file, fileList)
-  qDebug() << "[info] Watching: " << file << "\n";
 
   QObject::connect(&watcher, SIGNAL(fileChanged(QString)), this,
                    SLOT(updateGUI(QString)));

--- a/gui/SlidersOfEvil/mainwindow.cpp
+++ b/gui/SlidersOfEvil/mainwindow.cpp
@@ -30,40 +30,6 @@ MainWindow::MainWindow(QWidget* parent) :
 }
 
 MainWindow::~MainWindow() {
-  // Set defaults
-  int e;
-  e = system("echo -n 3 > /sys/module/tcp_evil/parameters/hystart_detect");
-  if (e != 0) {
-    cout << "[ERROR] Couldn't set defaults." << endl;
-  }
-  e = system("echo -n 1 > /sys/module/tcp_evil/parameters/fast_convergence");
-  if (e != 0) {
-    cout << "[ERROR] Couldn't set defaults." << endl;
-  }
-  e = system("echo -n 1 > /sys/module/tcp_evil/parameters/tcp_friendliness");
-  if (e != 0) {
-    cout << "[ERROR] Couldn't set defaults." << endl;
-  }
-  e = system("echo -n 1 > /sys/module/tcp_evil/parameters/hystart");
-  if (e != 0) {
-    cout << "[ERROR] Couldn't set defaults." << endl;
-  }
-  e = system("echo -n 0 > /sys/module/tcp_evil/parameters/initial_ssthresh");
-  if (e != 0) {
-    cout << "[ERROR] Couldn't set defaults." << endl;
-  }
-  e = system("echo -n 16 > /sys/module/tcp_evil/parameters/hystart_low_window");
-  if (e != 0) {
-    cout << "[ERROR] Couldn't set defaults." << endl;
-  }
-  e = system("echo -n 2 > /sys/module/tcp_evil/parameters/hystart_ack_delta");
-  if (e != 0) {
-    cout << "[ERROR] Couldn't set defaults." << endl;
-  }
-  e = system("echo -n 717 > /sys/module/tcp_evil/parameters/beta");
-  if (e != 0) {
-    cout << "[ERROR] Couldn't set defaults." << endl;
-  }
   delete ui;
 }
 
@@ -238,4 +204,42 @@ void MainWindow::on_slider_rtt_valueChanged(int value) {
 }
 
 void MainWindow::on_slider_rttvar_valueChanged(int value) {
+}
+
+void MainWindow::on_btn_restoreDefaults_clicked()
+{
+    // Set defaults
+    int e;
+    e = system("echo -n 3 > /sys/module/tcp_evil/parameters/hystart_detect");
+    if (e != 0) {
+      cout << "[ERROR] Couldn't set defaults." << endl;
+    }
+    e = system("echo -n 1 > /sys/module/tcp_evil/parameters/fast_convergence");
+    if (e != 0) {
+      cout << "[ERROR] Couldn't set defaults." << endl;
+    }
+    e = system("echo -n 1 > /sys/module/tcp_evil/parameters/tcp_friendliness");
+    if (e != 0) {
+      cout << "[ERROR] Couldn't set defaults." << endl;
+    }
+    e = system("echo -n 1 > /sys/module/tcp_evil/parameters/hystart");
+    if (e != 0) {
+      cout << "[ERROR] Couldn't set defaults." << endl;
+    }
+    e = system("echo -n 0 > /sys/module/tcp_evil/parameters/initial_ssthresh");
+    if (e != 0) {
+      cout << "[ERROR] Couldn't set defaults." << endl;
+    }
+    e = system("echo -n 16 > /sys/module/tcp_evil/parameters/hystart_low_window");
+    if (e != 0) {
+      cout << "[ERROR] Couldn't set defaults." << endl;
+    }
+    e = system("echo -n 2 > /sys/module/tcp_evil/parameters/hystart_ack_delta");
+    if (e != 0) {
+      cout << "[ERROR] Couldn't set defaults." << endl;
+    }
+    e = system("echo -n 717 > /sys/module/tcp_evil/parameters/beta");
+    if (e != 0) {
+      cout << "[ERROR] Couldn't set defaults." << endl;
+    }
 }

--- a/gui/SlidersOfEvil/mainwindow.cpp
+++ b/gui/SlidersOfEvil/mainwindow.cpp
@@ -17,14 +17,47 @@ MainWindow::MainWindow(QWidget* parent) :
 
 MainWindow::~MainWindow() {
   // Set defaults
-  system("echo -n 3 > /sys/module/tcp_evil/parameters/hystart_detect");
-  system("echo -n 1 > /sys/module/tcp_evil/parameters/fast_convergence");
-  system("echo -n 1 > /sys/module/tcp_evil/parameters/tcp_friendliness");
-  system("echo -n 1 > /sys/module/tcp_evil/parameters/hystart");
-  system("echo -n 0 > /sys/module/tcp_evil/parameters/initial_ssthresh");
-  system("echo -n 16 > /sys/module/tcp_evil/parameters/hystart_low_window");
-  system("echo -n 2 > /sys/module/tcp_evil/parameters/hystart_ack_delta");
-  system("echo -n 717 > /sys/module/tcp_evil/parameters/beta");
+  int e;
+  e = system("echo -n 3 > /sys/module/tcp_evil/parameters/hystart_detect");
+  if (e != 0) {
+    cout << "[ERROR] Couldn't set defaults." << endl;
+    exit(EXIT_FAILURE);
+  }
+  e = system("echo -n 1 > /sys/module/tcp_evil/parameters/fast_convergence");
+  if (e != 0) {
+    cout << "[ERROR] Couldn't set defaults." << endl;
+    exit(EXIT_FAILURE);
+  }
+  e = system("echo -n 1 > /sys/module/tcp_evil/parameters/tcp_friendliness");
+  if (e != 0) {
+    cout << "[ERROR] Couldn't set defaults." << endl;
+    exit(EXIT_FAILURE);
+  }
+  e = system("echo -n 1 > /sys/module/tcp_evil/parameters/hystart");
+  if (e != 0) {
+    cout << "[ERROR] Couldn't set defaults." << endl;
+    exit(EXIT_FAILURE);
+  }
+  e = system("echo -n 0 > /sys/module/tcp_evil/parameters/initial_ssthresh");
+  if (e != 0) {
+    cout << "[ERROR] Couldn't set defaults." << endl;
+    exit(EXIT_FAILURE);
+  }
+  e = system("echo -n 16 > /sys/module/tcp_evil/parameters/hystart_low_window");
+  if (e != 0) {
+    cout << "[ERROR] Couldn't set defaults." << endl;
+    exit(EXIT_FAILURE);
+  }
+  e = system("echo -n 2 > /sys/module/tcp_evil/parameters/hystart_ack_delta");
+  if (e != 0) {
+    cout << "[ERROR] Couldn't set defaults." << endl;
+    exit(EXIT_FAILURE);
+  }
+  e = system("echo -n 717 > /sys/module/tcp_evil/parameters/beta");
+  if (e != 0) {
+    cout << "[ERROR] Couldn't set defaults." << endl;
+    exit(EXIT_FAILURE);
+  }
   delete ui;
 }
 
@@ -33,92 +66,134 @@ void MainWindow::on_actionExit_triggered() {
 }
 
 void MainWindow::on_rb_packet_train_clicked() {
-  system("echo -n 1 > /sys/module/tcp_evil/parameters/hystart_detect");
+  int status;
+  status = system("echo -n 1 > /sys/module/tcp_evil/parameters/hystart_detect");
+  if (status != 0) {
+    cout << "[ERROR] Could not set hystart_detect." << endl;
+  }
   cout << "Hystart Detect set to Packet Train" << endl;
 }
 
 void MainWindow::on_rb_delay_clicked() {
-  system("echo -n 2 > /sys/module/tcp_evil/parameters/hystart_detect");
+  int status;
+  status = system("echo -n 2 > /sys/module/tcp_evil/parameters/hystart_detect");
+  if (status != 0) {
+    cout << "[ERROR] Could not set hystart_detect." << endl;
+  }
   cout << "Hystart Detect set to Delay" << endl;
 }
 
 void MainWindow::on_rb_both_clicked() {
-  system("echo -n 3 > /sys/module/tcp_evil/parameters/hystart_detect");
+  int status;
+  status = system("echo -n 3 > /sys/module/tcp_evil/parameters/hystart_detect");
+  if (status != 0) {
+    cout << "[ERROR] Could not set hystart_detect." << endl;
+  }
   cout << "Hystart Detect set to both Delay and Packet Train" << endl;
 }
 
 void MainWindow::on_chk_fast_convergence_toggled(bool checked) {
+  int e;
   if (checked) {
-    system("echo -n 1 > /sys/module/tcp_evil/parameters/fast_convergence");
+    e = system("echo -n 1 > /sys/module/tcp_evil/parameters/fast_convergence");
   }
   else {
-    system("echo -n 0 > /sys/module/tcp_evil/parameters/fast_convergence");
+    e = system("echo -n 0 > /sys/module/tcp_evil/parameters/fast_convergence");
   }
-  // system(
-  //   "(echo -n Fast Convergence: ) && (cat /sys/module/tcp_evil/parameters/fast_convergence)");
+  if (e != 0) {
+    cout << "[ERROR] Could not set fast_convergence." << endl;
+  }
 }
 
 void MainWindow::on_chk_tcp_friendliness_toggled(bool checked) {
+  int e;
   if (checked) {
-    system("echo -n 1 > /sys/module/tcp_evil/parameters/tcp_friendliness");
+    e = system("echo -n 1 > /sys/module/tcp_evil/parameters/tcp_friendliness");
   }
   else {
-    system("echo -n 0 > /sys/module/tcp_evil/parameters/tcp_friendliness");
+    e = system("echo -n 0 > /sys/module/tcp_evil/parameters/tcp_friendliness");
   }
-  // system(
-  //   "(echo -n tcp_friendliness: ) && (cat /sys/module/tcp_evil/parameters/tcp_friendliness)");
+  if (e != 0) {
+    cout << "[ERROR] Could not set tcp_friendliness." << endl;
+  }
 }
 
 void MainWindow::on_chk_hystart_toggled(bool checked) {
+  int e;
   if (checked) {
-    system("echo -n 1 > /sys/module/tcp_evil/parameters/hystart");
+    e = system("echo -n 1 > /sys/module/tcp_evil/parameters/hystart");
   }
   else {
-    system("echo -n 0 > /sys/module/tcp_evil/parameters/hystart");
+    e = system("echo -n 0 > /sys/module/tcp_evil/parameters/hystart");
   }
-  // system(
-  //   "(echo -n hystart: ) && (cat /sys/module/tcp_evil/parameters/hystart)");
+  if (e != 0) {
+    cout << "[ERROR] Could not set hystart." << endl;
+  }
 }
 
 void MainWindow::on_slider_alpha_valueChanged(int value) {
+  int status;
   stringstream ss;
   ss << "echo -n " << value <<
     " > /sys/module/tcp_evil/parameters/alpha";
-  system(ss.str().c_str());
+  status = system(ss.str().c_str());
+  if (status != 0) {
+    cout << "[ERROR] Could not set alpha." << endl;
+  }
 }
 
 void MainWindow::on_slider_beta_valueChanged(int value) {
+  int status;
   stringstream ss;
   ss << "echo -n " << value << " > /sys/module/tcp_evil/parameters/beta";
-  system(ss.str().c_str());
+  status = system(ss.str().c_str());
+  if (status != 0) {
+    cout << "[ERROR] Could not set beta." << endl;
+  }
 }
 
 void MainWindow::on_slider_ack_delta_valueChanged(int value) {
+  int status;
   stringstream ss;
   ss << "echo -n " << value <<
     " > /sys/module/tcp_evil/parameters/hystart_ack_delta";
-  system(ss.str().c_str());
+  status = system(ss.str().c_str());
+  if (status != 0) {
+    cout << "[ERROR] Could not set hystart_ack_delta." << endl;
+  }
 }
 
 void MainWindow::on_slider_low_window_valueChanged(int value) {
+  int status;
   stringstream ss;
   ss << "echo -n " << value <<
     " > /sys/module/tcp_evil/parameters/hystart_low_window";
-  system(ss.str().c_str());
+  status = system(ss.str().c_str());
+  if (status != 0) {
+    cout << "[ERROR] Could not set hystart_low_window." << endl;
+  }
 }
 
 void MainWindow::on_slider_ssthresh_valueChanged(int value) {
+  int status;
   stringstream ss;
   ss << "echo -n " << value <<
     " > /sys/module/tcp_evil/parameters/initial_ssthresh";
-  system(ss.str().c_str());
+  status = system(ss.str().c_str());
+  if (status != 0) {
+    cout << "[ERROR] Could not set initial_sshtresh." << endl;
+  }
 }
 
 void MainWindow::on_chk_use_alpha_toggled(bool checked) {
+  int e;
   if (checked) {
-    system("echo -n 1 > /sys/module/tcp_evil/parameters/use_alpha");
+    e = system("echo -n 1 > /sys/module/tcp_evil/parameters/use_alpha");
   }
   else {
-    system("echo -n 0 > /sys/module/tcp_evil/parameters/use_alpha");
+    e = system("echo -n 0 > /sys/module/tcp_evil/parameters/use_alpha");
+  }
+  if (e != 0) {
+    cout << "[ERROR] Could not set use_alpha." << endl;
   }
 }

--- a/gui/SlidersOfEvil/mainwindow.cpp
+++ b/gui/SlidersOfEvil/mainwindow.cpp
@@ -212,6 +212,9 @@ void MainWindow::on_slider_rto_min_valueChanged(int value) {
   if (i != string::npos) {
     route.erase(route.begin()+i, route.end());
   }
+  else {
+    route.pop_back();
+  }
   stringstream ss;
   ss << "ip route change " << route << " rto_min " << value << "ms";
 

--- a/gui/SlidersOfEvil/mainwindow.h
+++ b/gui/SlidersOfEvil/mainwindow.h
@@ -53,6 +53,8 @@ private slots:
 
   void on_slider_rttvar_valueChanged(int value);
 
+  void on_btn_restoreDefaults_clicked();
+
 private:
   Ui::MainWindow* ui;
 };

--- a/gui/SlidersOfEvil/mainwindow.h
+++ b/gui/SlidersOfEvil/mainwindow.h
@@ -29,21 +29,17 @@ private slots:
 
   void on_chk_hystart_toggled(bool checked);
 
-  void on_slider_beta_sliderMoved(int position);
+  void on_slider_beta_valueChanged(int value);
 
-  void on_slider_beta_sliderReleased();
+  void on_slider_alpha_valueChanged(int value);
 
-  void on_slider_ack_delta_sliderMoved(int position);
+  void on_slider_ack_delta_valueChanged(int value);
 
-  void on_slider_ack_delta_sliderReleased();
+  void on_slider_low_window_valueChanged(int value);
 
-  void on_slider_low_window_sliderMoved(int position);
+  void on_slider_ssthresh_valueChanged(int value);
 
-  void on_slider_low_window_sliderReleased();
-
-  void on_slider_ssthresh_sliderMoved(int position);
-
-  void on_slider_ssthresh_sliderReleased();
+  void on_chk_use_alpha_toggled(bool checked);
 
 private:
   Ui::MainWindow* ui;

--- a/gui/SlidersOfEvil/mainwindow.h
+++ b/gui/SlidersOfEvil/mainwindow.h
@@ -1,7 +1,9 @@
 #ifndef MAINWINDOW_H
 #define MAINWINDOW_H
 
+#include "paramwatcher.h"
 #include <QMainWindow>
+#include <QFileSystemWatcher>
 
 namespace Ui {
   class MainWindow;
@@ -17,11 +19,11 @@ public:
 private slots:
   void on_actionExit_triggered();
 
-  void on_rb_packet_train_clicked();
-
   void on_chk_fast_convergence_toggled(bool checked);
 
   void on_chk_tcp_friendliness_toggled(bool checked);
+
+  void on_rb_packet_train_clicked();
 
   void on_rb_delay_clicked();
 
@@ -55,8 +57,12 @@ private slots:
 
   void on_btn_restoreDefaults_clicked();
 
+  void updateGUI(const QString& str);
+
 private:
   Ui::MainWindow* ui;
+  QFileSystemWatcher watcher;
+  ParamWatcher pw;
 };
 
 #endif // MAINWINDOW_H

--- a/gui/SlidersOfEvil/mainwindow.ui
+++ b/gui/SlidersOfEvil/mainwindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>520</width>
-    <height>654</height>
+    <height>650</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -147,7 +147,7 @@
         </spacer>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="layout_beta">
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
           <widget class="QLabel" name="label_beta">
            <property name="minimumSize">
@@ -157,7 +157,7 @@
             </size>
            </property>
            <property name="text">
-            <string>beta</string>
+            <string>beta/1024</string>
            </property>
           </widget>
          </item>
@@ -190,6 +190,9 @@
            </property>
            <property name="maximum">
             <number>1024</number>
+           </property>
+           <property name="singleStep">
+            <number>1</number>
            </property>
            <property name="sliderPosition">
             <number>717</number>
@@ -1485,12 +1488,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>499</x>
-     <y>113</y>
+     <x>487</x>
+     <y>119</y>
     </hint>
     <hint type="destinationlabel">
-     <x>398</x>
-     <y>113</y>
+     <x>371</x>
+     <y>122</y>
     </hint>
    </hints>
   </connection>
@@ -1501,12 +1504,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>398</x>
-     <y>113</y>
+     <x>371</x>
+     <y>122</y>
     </hint>
     <hint type="destinationlabel">
-     <x>499</x>
-     <y>113</y>
+     <x>487</x>
+     <y>119</y>
     </hint>
    </hints>
   </connection>
@@ -1517,12 +1520,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>499</x>
-     <y>215</y>
+     <x>460</x>
+     <y>236</y>
     </hint>
     <hint type="destinationlabel">
-     <x>410</x>
-     <y>215</y>
+     <x>371</x>
+     <y>237</y>
     </hint>
    </hints>
   </connection>
@@ -1533,12 +1536,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>410</x>
-     <y>215</y>
+     <x>371</x>
+     <y>237</y>
     </hint>
     <hint type="destinationlabel">
-     <x>499</x>
-     <y>215</y>
+     <x>460</x>
+     <y>236</y>
     </hint>
    </hints>
   </connection>
@@ -1549,12 +1552,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>499</x>
-     <y>281</y>
+     <x>466</x>
+     <y>309</y>
     </hint>
     <hint type="destinationlabel">
-     <x>404</x>
-     <y>281</y>
+     <x>371</x>
+     <y>310</y>
     </hint>
    </hints>
   </connection>
@@ -1565,12 +1568,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>404</x>
-     <y>281</y>
+     <x>371</x>
+     <y>310</y>
     </hint>
     <hint type="destinationlabel">
-     <x>499</x>
-     <y>281</y>
+     <x>466</x>
+     <y>309</y>
     </hint>
    </hints>
   </connection>
@@ -1581,12 +1584,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>499</x>
-     <y>314</y>
+     <x>466</x>
+     <y>348</y>
     </hint>
     <hint type="destinationlabel">
-     <x>404</x>
-     <y>314</y>
+     <x>371</x>
+     <y>349</y>
     </hint>
    </hints>
   </connection>
@@ -1597,12 +1600,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>404</x>
-     <y>314</y>
+     <x>371</x>
+     <y>349</y>
     </hint>
     <hint type="destinationlabel">
-     <x>499</x>
-     <y>314</y>
+     <x>466</x>
+     <y>348</y>
     </hint>
    </hints>
   </connection>
@@ -1613,12 +1616,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>499</x>
-     <y>79</y>
+     <x>460</x>
+     <y>80</y>
     </hint>
     <hint type="destinationlabel">
-     <x>410</x>
-     <y>79</y>
+     <x>371</x>
+     <y>81</y>
     </hint>
    </hints>
   </connection>
@@ -1629,12 +1632,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>410</x>
-     <y>79</y>
+     <x>371</x>
+     <y>81</y>
     </hint>
     <hint type="destinationlabel">
-     <x>499</x>
-     <y>79</y>
+     <x>460</x>
+     <y>80</y>
     </hint>
    </hints>
   </connection>
@@ -1645,12 +1648,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>453</x>
-     <y>422</y>
+     <x>598</x>
+     <y>454</y>
     </hint>
     <hint type="destinationlabel">
-     <x>398</x>
-     <y>423</y>
+     <x>497</x>
+     <y>454</y>
     </hint>
    </hints>
   </connection>
@@ -1661,12 +1664,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>387</x>
-     <y>419</y>
+     <x>497</x>
+     <y>454</y>
     </hint>
     <hint type="destinationlabel">
-     <x>454</x>
-     <y>420</y>
+     <x>598</x>
+     <y>454</y>
     </hint>
    </hints>
   </connection>
@@ -1677,12 +1680,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>451</x>
-     <y>453</y>
+     <x>598</x>
+     <y>486</y>
     </hint>
     <hint type="destinationlabel">
-     <x>394</x>
-     <y>454</y>
+     <x>497</x>
+     <y>486</y>
     </hint>
    </hints>
   </connection>
@@ -1693,12 +1696,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>398</x>
-     <y>461</y>
+     <x>497</x>
+     <y>486</y>
     </hint>
     <hint type="destinationlabel">
-     <x>499</x>
-     <y>461</y>
+     <x>598</x>
+     <y>486</y>
     </hint>
    </hints>
   </connection>
@@ -1709,12 +1712,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>452</x>
-     <y>488</y>
+     <x>598</x>
+     <y>518</y>
     </hint>
     <hint type="destinationlabel">
-     <x>391</x>
-     <y>489</y>
+     <x>497</x>
+     <y>518</y>
     </hint>
    </hints>
   </connection>
@@ -1725,12 +1728,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>398</x>
-     <y>490</y>
+     <x>497</x>
+     <y>518</y>
     </hint>
     <hint type="destinationlabel">
-     <x>499</x>
-     <y>490</y>
+     <x>598</x>
+     <y>518</y>
     </hint>
    </hints>
   </connection>
@@ -1741,12 +1744,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>499</x>
-     <y>519</y>
+     <x>598</x>
+     <y>550</y>
     </hint>
     <hint type="destinationlabel">
-     <x>398</x>
-     <y>519</y>
+     <x>497</x>
+     <y>550</y>
     </hint>
    </hints>
   </connection>
@@ -1757,12 +1760,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>398</x>
-     <y>519</y>
+     <x>497</x>
+     <y>550</y>
     </hint>
     <hint type="destinationlabel">
-     <x>499</x>
-     <y>519</y>
+     <x>598</x>
+     <y>550</y>
     </hint>
    </hints>
   </connection>
@@ -1773,12 +1776,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>499</x>
-     <y>548</y>
+     <x>598</x>
+     <y>582</y>
     </hint>
     <hint type="destinationlabel">
-     <x>404</x>
-     <y>548</y>
+     <x>503</x>
+     <y>582</y>
     </hint>
    </hints>
   </connection>
@@ -1789,12 +1792,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>404</x>
-     <y>548</y>
+     <x>503</x>
+     <y>582</y>
     </hint>
     <hint type="destinationlabel">
-     <x>499</x>
-     <y>548</y>
+     <x>598</x>
+     <y>582</y>
     </hint>
    </hints>
   </connection>
@@ -1805,12 +1808,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>398</x>
-     <y>577</y>
+     <x>497</x>
+     <y>614</y>
     </hint>
     <hint type="destinationlabel">
-     <x>499</x>
-     <y>577</y>
+     <x>598</x>
+     <y>614</y>
     </hint>
    </hints>
   </connection>
@@ -1821,12 +1824,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>499</x>
-     <y>577</y>
+     <x>598</x>
+     <y>614</y>
     </hint>
     <hint type="destinationlabel">
-     <x>398</x>
-     <y>577</y>
+     <x>497</x>
+     <y>614</y>
     </hint>
    </hints>
   </connection>

--- a/gui/SlidersOfEvil/mainwindow.ui
+++ b/gui/SlidersOfEvil/mainwindow.ui
@@ -92,7 +92,7 @@
             <number>1</number>
            </property>
            <property name="maximum">
-            <number>20</number>
+            <number>10</number>
            </property>
            <property name="value">
             <number>1</number>
@@ -127,7 +127,7 @@
             <number>1</number>
            </property>
            <property name="maximum">
-            <number>20</number>
+            <number>10</number>
            </property>
            <property name="value">
             <number>1</number>
@@ -192,7 +192,7 @@
             <number>1</number>
            </property>
            <property name="maximum">
-            <number>2048</number>
+            <number>1024</number>
            </property>
            <property name="sliderPosition">
             <number>717</number>
@@ -224,7 +224,7 @@
             <number>1</number>
            </property>
            <property name="maximum">
-            <number>2048</number>
+            <number>1024</number>
            </property>
            <property name="value">
             <number>717</number>

--- a/gui/SlidersOfEvil/mainwindow.ui
+++ b/gui/SlidersOfEvil/mainwindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>520</width>
+    <width>646</width>
     <height>650</height>
    </rect>
   </property>
@@ -1424,6 +1424,19 @@
       </layout>
      </widget>
     </item>
+    <item>
+     <widget class="QPushButton" name="btn_restoreDefaults">
+      <property name="maximumSize">
+       <size>
+        <width>16777215</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>Restore Cubic Defaults</string>
+      </property>
+     </widget>
+    </item>
    </layout>
   </widget>
   <widget class="QMenuBar" name="menuBar">
@@ -1431,7 +1444,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>520</width>
+     <width>646</width>
      <height>21</height>
     </rect>
    </property>

--- a/gui/SlidersOfEvil/mainwindow.ui
+++ b/gui/SlidersOfEvil/mainwindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>520</width>
-    <height>562</height>
+    <height>500</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -34,7 +34,7 @@
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
-        <spacer name="verticalSpacer">
+        <spacer name="verticalSpacer_10">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -49,6 +49,109 @@
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
+          <widget class="QCheckBox" name="chk_use_alpha">
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>use_alpha:</string>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="spacer_alpha_l">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Minimum</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QSlider" name="slider_alpha">
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>200</number>
+           </property>
+           <property name="value">
+            <number>1</number>
+           </property>
+           <property name="sliderPosition">
+            <number>1</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="spacer_alpha_r">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Minimum</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="alpha_value">
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>200</number>
+           </property>
+           <property name="value">
+            <number>1</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>9</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="layout_beta">
+         <item>
           <widget class="QLabel" name="label_beta">
            <property name="minimumSize">
             <size>
@@ -62,7 +165,7 @@
           </widget>
          </item>
          <item>
-          <spacer name="spacer_beta">
+          <spacer name="spacer_beta_l">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -100,7 +203,7 @@
           </widget>
          </item>
          <item>
-          <spacer name="spacer_beta_2">
+          <spacer name="spacer_beta_r">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -144,7 +247,7 @@
         </spacer>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="laout_fast_convergence">
+        <layout class="QHBoxLayout" name="layout_fast_convergence">
          <item>
           <spacer name="spacer_fast_l">
            <property name="orientation">
@@ -262,7 +365,7 @@
         </spacer>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <layout class="QHBoxLayout" name="layout_hystartackdelta">
          <item>
           <widget class="QLabel" name="label_ack_delta">
            <property name="minimumSize">
@@ -315,7 +418,7 @@
           </widget>
          </item>
          <item>
-          <spacer name="spacer_beta_3">
+          <spacer name="spaceer_ack_delta_r">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -331,7 +434,7 @@
           </spacer>
          </item>
          <item>
-          <widget class="QSpinBox" name="beta_value_2">
+          <widget class="QSpinBox" name="hystartackdelta_value">
            <property name="minimum">
             <number>1</number>
            </property>
@@ -438,7 +541,7 @@
         </spacer>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <layout class="QHBoxLayout" name="layout_low_window">
          <item>
           <widget class="QLabel" name="label_low_window">
            <property name="minimumSize">
@@ -491,7 +594,7 @@
           </widget>
          </item>
          <item>
-          <spacer name="spacer_beta_4">
+          <spacer name="spacer_low_window_r">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -507,7 +610,7 @@
           </spacer>
          </item>
          <item>
-          <widget class="QSpinBox" name="beta_value_3">
+          <widget class="QSpinBox" name="low_window_value">
            <property name="minimum">
             <number>1</number>
            </property>
@@ -535,7 +638,7 @@
         </spacer>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <layout class="QHBoxLayout" name="layout_initial_ssthresh">
          <item>
           <widget class="QLabel" name="label_ssthresh">
            <property name="minimumSize">
@@ -588,7 +691,7 @@
           </widget>
          </item>
          <item>
-          <spacer name="spacer_beta_5">
+          <spacer name="spacer_ssthresh_r">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -604,7 +707,7 @@
           </spacer>
          </item>
          <item>
-          <widget class="QSpinBox" name="beta_value_4">
+          <widget class="QSpinBox" name="ssthresh_value">
            <property name="minimum">
             <number>0</number>
            </property>
@@ -757,12 +860,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>407</x>
-     <y>76</y>
+     <x>473</x>
+     <y>142</y>
     </hint>
     <hint type="destinationlabel">
-     <x>325</x>
-     <y>77</y>
+     <x>372</x>
+     <y>143</y>
     </hint>
    </hints>
   </connection>
@@ -773,108 +876,140 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>343</x>
-     <y>77</y>
+     <x>372</x>
+     <y>143</y>
     </hint>
     <hint type="destinationlabel">
-     <x>444</x>
-     <y>76</y>
+     <x>473</x>
+     <y>142</y>
     </hint>
    </hints>
   </connection>
   <connection>
-   <sender>beta_value_2</sender>
+   <sender>hystartackdelta_value</sender>
    <signal>valueChanged(int)</signal>
    <receiver>slider_ack_delta</receiver>
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>464</x>
-     <y>219</y>
+     <x>461</x>
+     <y>282</y>
     </hint>
     <hint type="destinationlabel">
-     <x>393</x>
-     <y>221</y>
+     <x>372</x>
+     <y>283</y>
     </hint>
    </hints>
   </connection>
   <connection>
    <sender>slider_ack_delta</sender>
    <signal>valueChanged(int)</signal>
-   <receiver>beta_value_2</receiver>
+   <receiver>hystartackdelta_value</receiver>
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>396</x>
-     <y>231</y>
+     <x>372</x>
+     <y>283</y>
     </hint>
     <hint type="destinationlabel">
-     <x>460</x>
-     <y>230</y>
+     <x>461</x>
+     <y>282</y>
     </hint>
    </hints>
   </connection>
   <connection>
-   <sender>beta_value_3</sender>
+   <sender>low_window_value</sender>
    <signal>valueChanged(int)</signal>
    <receiver>slider_low_window</receiver>
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>477</x>
-     <y>347</y>
+     <x>467</x>
+     <y>382</y>
     </hint>
     <hint type="destinationlabel">
-     <x>418</x>
-     <y>345</y>
+     <x>372</x>
+     <y>383</y>
     </hint>
    </hints>
   </connection>
   <connection>
    <sender>slider_low_window</sender>
    <signal>valueChanged(int)</signal>
-   <receiver>beta_value_3</receiver>
+   <receiver>low_window_value</receiver>
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>420</x>
-     <y>356</y>
+     <x>372</x>
+     <y>383</y>
     </hint>
     <hint type="destinationlabel">
-     <x>483</x>
-     <y>356</y>
+     <x>467</x>
+     <y>382</y>
     </hint>
    </hints>
   </connection>
   <connection>
-   <sender>beta_value_4</sender>
+   <sender>ssthresh_value</sender>
    <signal>valueChanged(int)</signal>
    <receiver>slider_ssthresh</receiver>
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>447</x>
-     <y>401</y>
+     <x>457</x>
+     <y>432</y>
     </hint>
     <hint type="destinationlabel">
-     <x>386</x>
-     <y>396</y>
+     <x>362</x>
+     <y>433</y>
     </hint>
    </hints>
   </connection>
   <connection>
    <sender>slider_ssthresh</sender>
    <signal>valueChanged(int)</signal>
-   <receiver>beta_value_4</receiver>
+   <receiver>ssthresh_value</receiver>
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>388</x>
-     <y>409</y>
+     <x>362</x>
+     <y>433</y>
     </hint>
     <hint type="destinationlabel">
-     <x>452</x>
-     <y>407</y>
+     <x>457</x>
+     <y>432</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>alpha_value</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>slider_alpha</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>440</x>
+     <y>88</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>372</x>
+     <y>92</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>slider_alpha</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>alpha_value</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>349</x>
+     <y>102</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>438</x>
+     <y>102</y>
     </hint>
    </hints>
   </connection>

--- a/gui/SlidersOfEvil/mainwindow.ui
+++ b/gui/SlidersOfEvil/mainwindow.ui
@@ -92,7 +92,7 @@
             <number>1</number>
            </property>
            <property name="maximum">
-            <number>200</number>
+            <number>20</number>
            </property>
            <property name="value">
             <number>1</number>
@@ -127,7 +127,7 @@
             <number>1</number>
            </property>
            <property name="maximum">
-            <number>200</number>
+            <number>20</number>
            </property>
            <property name="value">
             <number>1</number>

--- a/gui/SlidersOfEvil/mainwindow.ui
+++ b/gui/SlidersOfEvil/mainwindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>646</width>
-    <height>650</height>
+    <width>520</width>
+    <height>654</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -47,9 +47,9 @@
         </spacer>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="layout_alpha">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
-          <widget class="QCheckBox" name="chk_use_alpha">
+          <widget class="QLabel" name="label_alpha">
            <property name="minimumSize">
             <size>
              <width>100</width>
@@ -57,10 +57,7 @@
             </size>
            </property>
            <property name="text">
-            <string>use_alpha:</string>
-           </property>
-           <property name="checked">
-            <bool>false</bool>
+            <string>alpha</string>
            </property>
           </widget>
          </item>
@@ -1444,7 +1441,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>646</width>
+     <width>520</width>
      <height>21</height>
     </rect>
    </property>
@@ -1696,12 +1693,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>397</x>
-     <y>464</y>
+     <x>398</x>
+     <y>461</y>
     </hint>
     <hint type="destinationlabel">
-     <x>457</x>
-     <y>467</y>
+     <x>499</x>
+     <y>461</y>
     </hint>
    </hints>
   </connection>
@@ -1729,11 +1726,11 @@
    <hints>
     <hint type="sourcelabel">
      <x>398</x>
-     <y>498</y>
+     <y>490</y>
     </hint>
     <hint type="destinationlabel">
-     <x>460</x>
-     <y>500</y>
+     <x>499</x>
+     <y>490</y>
     </hint>
    </hints>
   </connection>
@@ -1744,12 +1741,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>451</x>
-     <y>522</y>
+     <x>499</x>
+     <y>519</y>
     </hint>
     <hint type="destinationlabel">
-     <x>395</x>
-     <y>521</y>
+     <x>398</x>
+     <y>519</y>
     </hint>
    </hints>
   </connection>
@@ -1760,12 +1757,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>393</x>
-     <y>532</y>
+     <x>398</x>
+     <y>519</y>
     </hint>
     <hint type="destinationlabel">
-     <x>453</x>
-     <y>532</y>
+     <x>499</x>
+     <y>519</y>
     </hint>
    </hints>
   </connection>
@@ -1776,12 +1773,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>459</x>
-     <y>555</y>
+     <x>499</x>
+     <y>548</y>
     </hint>
     <hint type="destinationlabel">
-     <x>403</x>
-     <y>555</y>
+     <x>404</x>
+     <y>548</y>
     </hint>
    </hints>
   </connection>
@@ -1792,12 +1789,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>394</x>
-     <y>567</y>
+     <x>404</x>
+     <y>548</y>
     </hint>
     <hint type="destinationlabel">
-     <x>469</x>
-     <y>568</y>
+     <x>499</x>
+     <y>548</y>
     </hint>
    </hints>
   </connection>
@@ -1808,12 +1805,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>393</x>
-     <y>591</y>
+     <x>398</x>
+     <y>577</y>
     </hint>
     <hint type="destinationlabel">
-     <x>454</x>
-     <y>589</y>
+     <x>499</x>
+     <y>577</y>
     </hint>
    </hints>
   </connection>
@@ -1824,12 +1821,12 @@
    <slot>setValue(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>453</x>
-     <y>597</y>
+     <x>499</x>
+     <y>577</y>
     </hint>
     <hint type="destinationlabel">
-     <x>394</x>
-     <y>595</y>
+     <x>398</x>
+     <y>577</y>
     </hint>
    </hints>
   </connection>

--- a/mahimahi/server.py
+++ b/mahimahi/server.py
@@ -15,18 +15,18 @@ def handle_connection(conn):
 if len(sys.argv) != 2:
     print "usage: python server.py PORT"
     sys.exit(-1)
- 
-PORT = int(sys.argv[1]) 
- 
+
+PORT = int(sys.argv[1])
+
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
- 
+
 try:
     s.bind(('', PORT))
 except socket.error:
     print "bind error"
     sys.exit(-1)
-     
+
 s.listen(1) #only have 1 connection
 print "Awaiting connection on port %d" % PORT
 
@@ -34,5 +34,5 @@ while (True):
     conn,_ = s.accept()
     print "Accepted connection"
     thread.start_new_thread(handle_connection, (conn,))
-     
+
 s.close()

--- a/mahimahi/start_all
+++ b/mahimahi/start_all
@@ -8,13 +8,13 @@ if ( $receiver_pid < 0 ) {
   die qq{$!};
 } elsif ( $receiver_pid == 0 ) {
   # child
-  exec q{./server.py 5051} or die qq{$!};
+  exec q{./server.py 5052} or die qq{$!};
 }
 
 # run the sender inside a linkshell and a delayshell
 my @command = qw{mm-delay 40 mm-link UPLINK DOWNLINK --downlink-queue=droptail --downlink-queue-args=bytes=120000 --uplink-queue=droptail --uplink-queue-args=bytes=120000 --meter-uplink --meter-uplink-delay --uplink-log=/tmp/tcpvil_uplink_log -- sh -c};
 
-push @command, q{./client.py 5051};
+push @command, q{./client.py 5052};
 
 # for the contest, we will send data over Verizon's downlink
 # (datagrump sender's uplink)

--- a/mahimahi/start_all
+++ b/mahimahi/start_all
@@ -8,13 +8,13 @@ if ( $receiver_pid < 0 ) {
   die qq{$!};
 } elsif ( $receiver_pid == 0 ) {
   # child
-  exec q{./server.py 5052} or die qq{$!};
+  exec q{./server.py 5051} or die qq{$!};
 }
 
 # run the sender inside a linkshell and a delayshell
-my @command = qw{mm-delay 20 mm-link UPLINK DOWNLINK --downlink-queue=droptail --downlink-queue-args=bytes=60000 --uplink-queue=droptail --uplink-queue-args=bytes=60000 --meter-uplink --meter-uplink-delay --uplink-log=/tmp/tcpvil_uplink_log -- sh -c};
+my @command = qw{mm-delay 40 mm-link UPLINK DOWNLINK --downlink-queue=droptail --downlink-queue-args=bytes=120000 --uplink-queue=droptail --uplink-queue-args=bytes=120000 --meter-uplink --meter-uplink-delay --uplink-log=/tmp/tcpvil_uplink_log -- sh -c};
 
-push @command, q{./client.py 5052};
+push @command, q{./client.py 5051};
 
 # for the contest, we will send data over Verizon's downlink
 # (datagrump sender's uplink)

--- a/module/tcp_evil.c
+++ b/module/tcp_evil.c
@@ -44,8 +44,7 @@
 #define HYSTART_DELAY_THRESH(x) clamp(x, HYSTART_DELAY_MIN, HYSTART_DELAY_MAX)
 
 static int fast_convergence __read_mostly = 1;
-static int alpha __read_mostly = 1; /* only considered is use_alpha is enabled */
-static int use_alpha __read_mostly = 0;
+static int alpha __read_mostly = 1; 
 static int beta __read_mostly = 717;     /* = 717/1024 (BICTCP_BETA_SCALE) */
 static int initial_ssthresh __read_mostly;
 static int bic_scale __read_mostly = 41;
@@ -65,8 +64,6 @@ module_param(fast_convergence, int, 0644);
 MODULE_PARM_DESC(fast_convergence, "turn on/off fast convergence");
 module_param(alpha, int, 0644);
 MODULE_PARM_DESC(alpha, "alpha to increase cwnd by per ack");
-module_param(use_alpha, int, 0644);
-MODULE_PARM_DESC(use_alpha, "Use a set additive increase rather than CUBIC");
 module_param(beta, int, 0644);
 MODULE_PARM_DESC(beta, "beta for multiplicative increase");
 module_param(initial_ssthresh, int, 0644);
@@ -340,12 +337,7 @@ void evil_cong_avoid_ai(struct tcp_sock* tp, u32 w, u32 acked) {
   /* If credits accumulated at a higher w, apply them gently now. */
   if (tp->snd_cwnd_cnt >= w) {
     tp->snd_cwnd_cnt = 0;
-    if (use_alpha) {
-      tp->snd_cwnd += alpha;
-    }
-    else {
-      tp->snd_cwnd++;
-    }
+    tp->snd_cwnd += alpha;
   }
 
   tp->snd_cwnd_cnt += acked;

--- a/module/tcp_evil.c
+++ b/module/tcp_evil.c
@@ -326,14 +326,6 @@ tcp_friendliness:
    * 2 packets ACKed, meaning cwnd grows at 1.5x per RTT.
    */
   ca->cnt = max(ca->cnt, 2U);
-
-  /**
-   * Added by TCPvil to allow control over an additive increase based on then
-   * module parameters.
-   */
-  if (use_alpha) {
-    printk(KERN_INFO "%d\n", ca->cnt);
-  }
 }
 
 /**


### PR DESCRIPTION
This PR implements exposing the amount that the tcp sender's cwnd is incremented by (alpha) and updates the mahi mahi scripts to allow us to not change port numbers. Delay was also increased so that we have a large bandwidth*delay product, which allows us to see the behavior of the cubic algorithm more clearly.
